### PR TITLE
Fixed deprecation of `multiprocess`

### DIFF
--- a/R/misty.R
+++ b/R/misty.R
@@ -1,7 +1,7 @@
 #' @importFrom magrittr %>%
 #' @importFrom rlang !! :=
 .onLoad <- function(libname, pkgname) {
-  suppressWarnings(future::plan(future::multiprocess))
+  suppressWarnings(future::plan(future::multisession))
 }
 
 


### PR DESCRIPTION
Fixes error on installation:
```
error: Initialization of plan() failed, because the test future used for validation failed. The reason was: (converted from warning) Strategy 'multiprocess' is deprecated in future (>= 1.20.0). Instead, explicitly specify either 'multisession' or 'multicore'. In the current R session, 'multiprocess' equals 'multisession'.
```